### PR TITLE
feat: Update to logic of app-interface flag for regions for safer newlines

### DIFF
--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -154,7 +154,10 @@ func ResourcesToYamlRegions(resources []map[string]interface{}, outputFile strin
 		for scanner.Scan() {
 			text := scanner.Text()
 			if strings.Contains(text, "cloud_regions:") {
-				finalText += fmt.Sprintf("%s\n%s\n", text, newConfigmap)
+				finalText += fmt.Sprintf("%s\n%s", text, newConfigmap)
+				if !strings.HasSuffix(newConfigmap, "\n") {
+					finalText += "\n"
+				}
 				break
 			} else {
 				finalText += fmt.Sprintf("%s\n", text)


### PR DESCRIPTION
There is a chance that running `--app-interface` for regions specifically could create a new `\n` at the end of the file, this makes sure that never happens